### PR TITLE
REMOVE LEFTOVER REFERENCES TO nPacMaps; Fixes #9

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,8 +17,8 @@ Description: This package contains functions for creating basemap polygons
     Walter H. F. Smith (NOAA Geosciences Lab, National Ocean Service, Silver 
     Spring, MD) for there dedication and maintenance of the GSHHG. Please cite
     their work if you use this package in a publication.
-Version: 1.0.0
-Date: 2018-10-24
+Version: 1.0.1
+Date: 2018-10-25
 URL: https://github.com/jmlondon/ptolemy
 BugReports: https://github.com/jmlondon/ptolemy/issues
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
-# ptolemy 1.0
+# ptolemy 1.0.1
+
+* There were some leftover references to nPacMaps that prevented install. These
+were removed and replaced with references to the new pkg name, ptolemy
+
+# ptolemy 1.0.0
 
 * Added a `NEWS.md` file to track changes to the package.
 * Renamed the package from "nPacMaps" to "ptolemy"

--- a/R/install_gshhg.R
+++ b/R/install_gshhg.R
@@ -8,10 +8,10 @@
 #' @export
 #'
 install_gshhg <- function() {
-  if (!dir.exists(system.file("extData", package = "nPacMaps"))) {
-    dir.create(system.file("extData", package = "nPacMaps"))
+  if (!dir.exists(system.file("extData", package = "ptolemy"))) {
+    dir.create(system.file("extData", package = "ptolemy"))
   }
-  data_path <- system.file("extData", package = "nPacMaps")
+  data_path <- system.file("extData", package = "ptolemy")
   
   if (!file.exists(paste(data_path, "gshhg-bin-2.3.7", sep = "/"))) {
     cont <- readline(

--- a/R/nPacMaps.R
+++ b/R/nPacMaps.R
@@ -1,7 +1,7 @@
-#' North Pacific Maps
+#' ptolemy: an R package for accessing global high-resolution geography
 #'
 #' @docType package
-#' @name nPacMaps
+#' @name ptolemy
 NULL
 
 .onAttach <- function(library, pkgname)
@@ -10,13 +10,13 @@ NULL
   package <- info$Package
   version <- info$Version
   date <- info$Date
-  if (dir.exists(system.file("extData", package = "nPacMaps"))) {
-    data_path <- system.file("extData", package = "nPacMaps")
+  if (dir.exists(system.file("extData", package = "ptolemy"))) {
+    data_path <- system.file("extData", package = "ptolemy")
   }
   if (!file.exists(paste(data_path, "gshhg-bin-2.3.7", sep = "/"))) {
   packageStartupMessage(
     paste(paste(package, version, paste0("(",date, ")"), "\n"), 
-          "The nPacMaps package requires an additional installation step.\n",
+          "The ptolemy package requires an additional installation step.\n",
           "Please type 'install_gshhg()' to install GSHHG v 2.3.7.\n"
           )
   )


### PR DESCRIPTION
There were leftover references to the old package name, `nPacMaps`, in a few key places. This should fix #9. Thank you to @rmendels for raising the issue. 